### PR TITLE
[ADD] spp_custom: read access on account.invoice for group_pos_user

### DIFF
--- a/spp_custom/__manifest__.py
+++ b/spp_custom/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "SPP Customizations",
     "version": "12.0.1.0.1",
-    "depends": ["beesdoo_base", "beesdoo_product"],
+    "depends": ["account", "beesdoo_base", "beesdoo_product", "point_of_sale"],
     "author": "Coop IT Easy SCRLfs",
     "license": "AGPL-3",
     "category": "",
@@ -13,6 +13,10 @@
     "summary": """
         Specifics customizations for SPP
     """,
-    "data": ["data/product_sequence.xml", "views/product.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/product_sequence.xml",
+        "views/product.xml",
+    ],
     "installable": True,
 }

--- a/spp_custom/security/ir.model.access.csv
+++ b/spp_custom/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_invoice_group_pos_user,account.invoice,account.model_account_invoice,point_of_sale.group_pos_user,1,0,0,0


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5472&view_type=form&model=project.task&action=479)

Allows creating an invoice from POS when user has only group_pos_user as group. 
(In standard, user needs to be part of "Technical Settings / Show Full Accounting Features" group)