### PR TITLE
[12.0][FIX] bees_custom: fix access to empty record

### DIFF
--- a/bees_custom/README.rst
+++ b/bees_custom/README.rst
@@ -25,6 +25,7 @@ Specifics customizations for BEES coop
 * label default_code as product location in product info screen
 * add consignment taxes in product info screen
 * request label printing button in product info screen
+* write in pos.order.note that an email was sent
 
 **Table of contents**
 

--- a/bees_custom/__manifest__.py
+++ b/bees_custom/__manifest__.py
@@ -7,6 +7,7 @@
     "depends": [
         "beesdoo_account",
         "beesdoo_product_info_screen",
+        "pos_mail_receipt",
     ],
     "author": "Coop IT Easy SCRLfs",
     "license": "AGPL-3",

--- a/bees_custom/models/__init__.py
+++ b/bees_custom/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_invoice
 from . import product_template
+from . import pos_order

--- a/bees_custom/models/pos_order.py
+++ b/bees_custom/models/pos_order.py
@@ -12,14 +12,14 @@ class PosOrder(models.Model):
     def send_mail_receipt(self, pos_reference, email, body_from_ui, force=True):
         order = self.search([("pos_reference", "=", pos_reference)])
 
-        order.note = "{}\n{} UTC Attempting to send mail receipt ".format(
-            order.note or "", fields.datetime.now()
-        )
+        if order:
+            order.note = "{}\n{} UTC Attempting to send mail receipt ".format(
+                order.note or "", fields.datetime.now()
+            )
 
         return super(PosOrder, self).send_mail_receipt(
-            # fixme forces argument force instead of passing it
             pos_reference,
             email,
             body_from_ui,
-            force=True,
+            force=force,
         )

--- a/bees_custom/models/pos_order.py
+++ b/bees_custom/models/pos_order.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    @api.model
+    def send_mail_receipt(self, pos_reference, email, body_from_ui, force=True):
+        order = self.search([("pos_reference", "=", pos_reference)])
+
+        order.note = "{}\n{} UTC Attempting to send mail receipt ".format(
+            order.note or "", fields.datetime.now()
+        )
+
+        return super(PosOrder, self).send_mail_receipt(
+            # fixme forces argument force instead of passing it
+            pos_reference,
+            email,
+            body_from_ui,
+            force=True,
+        )

--- a/bees_custom/readme/DESCRIPTION.rst
+++ b/bees_custom/readme/DESCRIPTION.rst
@@ -4,3 +4,4 @@ Specifics customizations for BEES coop
 * label default_code as product location in product info screen
 * add consignment taxes in product info screen
 * request label printing button in product info screen
+* write in pos.order.note that an email was sent

--- a/bees_custom/static/description/index.html
+++ b/bees_custom/static/description/index.html
@@ -374,6 +374,7 @@ ul.auto-toc {
 <li>label default_code as product location in product info screen</li>
 <li>add consignment taxes in product info screen</li>
 <li>request label printing button in product info screen</li>
+<li>write in pos.order.note that an email was sent</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">


### PR DESCRIPTION
# [TASK](https://gestion.coopiteasy.be/web?#id=7183&view_type=form&model=project.task&action=479)

1. `send_mail_receipt` function was moved from module `pos_print_receipt_backend` since it has nothing to do with printing tickets. The functions overloads a function from module `pos_mail_receipt`. Probably a leftover from moving the module to the OCA.  Moreover `pos_print_receipt_backend` lacked the inheritance to `pos_mail_receipt`.
2. I fixed the super access that was forcing the argument `force` to True
3. I check for the order to make sure I'm not accessing an empty recordset (like in `pos_mail_receipt`)

