### PR TITLE
[FIX] Freeze Python version to 3.9 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.9
 repos:
   - repo: local
     hooks:


### PR DESCRIPTION
pylint-odoo is incompatible with Python >3.9, see
<https://github.com/OCA/oca-addons-repo-template/issues/80> and
<https://github.com/coopiteasy/cie-repository-template/commit/04be2d44c0141161b5b34bc3211494413fc5ace0>.
