### PR TITLE
[IMP] provelo_custom: change menu items visibility

### DIFF
--- a/provelo_custom/readme/DESCRIPTION.rst
+++ b/provelo_custom/readme/DESCRIPTION.rst
@@ -5,6 +5,7 @@
 * location search filters
 * make payments view accessible for 'billing' group
 * customize holiday, timesheet and res_partner views
+* change the visibility of several leaves and timesheet sheet menu items
 * add the ``allocation_type`` field on ``hr.leave.report`` to allow to filter
   by it
 * add an "allocated" filter on ``hr.leave.report`` and enable it by default

--- a/provelo_custom/views/hr_holidays_view.xml
+++ b/provelo_custom/views/hr_holidays_view.xml
@@ -27,19 +27,35 @@
         </field>
     </record>
 
-<!--    <menuitem fixme-->
-<!--        parent="hr_holidays.menu_hr_holidays_my_leaves"-->
-<!--        id="hr_holidays.menu_open_allocation_holidays"-->
-<!--        action="hr_holidays.open_allocation_holidays"-->
-<!--        groups="base.group_hr_manager"-->
-<!--        sequence="40"-->
-<!--    />-->
+    <!--
+        make this menuitem visible to all users, instead of only to leaves
+        managers. the goal is for groups_id to be empty, but simply emptying
+        the group (with a 5 command) would cause any manual change to be lost
+        when the module is updated.
+    -->
+    <record model="ir.ui.menu" id="hr_holidays.menu_hr_holidays_dashboard">
+        <field
+            name="groups_id"
+            eval="[(3, ref('hr_holidays.group_hr_holidays_manager'))]"
+        />
+    </record>
 
-    <menuitem
-        name="Reports"
-        parent="hr_holidays.menu_hr_holidays_root"
-        id="hr_holidays.menu_hr_holidays_report"
-        groups="base.group_user"
-        sequence="99"
-    />
+    <!-- make this menuitem visible only to hr managers -->
+    <record model="ir.ui.menu" id="hr_holidays.menu_open_allocation">
+        <field name="groups_id" eval="[(4, ref('hr.group_hr_manager'))]" />
+    </record>
+
+    <!--
+        make this menuitem visible to all users, instead of only to leaves
+        managers and users. same remark about empty groups_id as above.
+    -->
+    <record model="ir.ui.menu" id="hr_holidays.menu_hr_holidays_report">
+        <field
+            name="groups_id"
+            eval="[
+                (3, ref('hr_holidays.group_hr_holidays_manager')),
+                (3, ref('hr_holidays.group_hr_holidays_user'))
+            ]"
+        />
+    </record>
 </odoo>

--- a/provelo_custom/views/hr_timesheet_sheet_view.xml
+++ b/provelo_custom/views/hr_timesheet_sheet_view.xml
@@ -63,4 +63,20 @@
 
         </field>
     </record>
+
+    <!--
+        make this menuitem visible to all users, instead of only to timesheet
+        managers. the goal is for groups_id to be empty, but simply emptying
+        the group (with a 5 command) would cause any manual change to be lost
+        when the module is updated.
+    -->
+    <record
+        model="ir.ui.menu"
+        id="hr_timesheet_sheet.menu_act_hr_timesheet_sheet_all_timesheets"
+    >
+        <field
+            name="groups_id"
+            eval="[(3, ref('hr_timesheet.group_timesheet_manager'))]"
+        />
+    </record>
 </odoo>


### PR DESCRIPTION
tasks: [t5002](https://gestion.coopiteasy.be/web#id=7704&view_type=form&model=project.task), [t4995](https://gestion.coopiteasy.be/web#id=7697&view_type=form&model=project.task)

change the visibility of several menu items:
    
*   make the leaves dashboard menu item visible to everyone, so that department managers can see the leaves of their subordinates.
*   make the leaves allocation requests menu item visible only to hr managers (like it was in version 9).
*   make the all timesheet sheets menu item visible to everyone.