### PR TITLE
12.0 provelo manager data access

### DIFF
--- a/provelo_custom/security/security.xml
+++ b/provelo_custom/security/security.xml
@@ -83,7 +83,7 @@
         <field name="perm_unlink" eval="True" />
         <field
             name="domain_force"
-        >[("employee_id.parent_id.user_id", "=", user.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.id)]</field>
     </record>
 
     <!-- an hr officer should have full access to all timesheet sheets -->

--- a/provelo_custom/security/security.xml
+++ b/provelo_custom/security/security.xml
@@ -37,9 +37,9 @@
         <field name="perm_write" eval="True" />
         <field name="perm_create" eval="True" />
         <field name="perm_unlink" eval="True" />
-        <field name="domain_force">[
-            ("user_id.employee_ids.parent_id", "=", user.employee_ids.id)
-            ]
+        <field
+            name="domain_force"
+        >[("employee_id", "child_of", user.employee_ids.mapped("id"))]
         </field>
     </record>
 
@@ -83,7 +83,7 @@
         <field name="perm_unlink" eval="True" />
         <field
             name="domain_force"
-        >[("employee_id", "child_of", user.employee_ids.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.mapped("id"))]</field>
     </record>
 
     <!-- an hr officer should have full access to all timesheet sheets -->
@@ -130,7 +130,7 @@
         <field name="perm_unlink" eval="True" />
         <field
             name="domain_force"
-        >[("employee_id", "child_of", user.employee_ids.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.mapped("id"))]</field>
     </record>
 
     <!-- leave reports -->
@@ -161,7 +161,7 @@
         <field name="perm_unlink" eval="False" />
         <field
             name="domain_force"
-        >[("employee_id", "child_of", user.employee_ids.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.mapped("id"))]</field>
     </record>
 
     <!-- an hr officer should have read-only access to all leave reports -->

--- a/provelo_custom/security/security.xml
+++ b/provelo_custom/security/security.xml
@@ -130,7 +130,7 @@
         <field name="perm_unlink" eval="True" />
         <field
             name="domain_force"
-        >[("employee_id.parent_id.user_id", "=", user.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.id)]</field>
     </record>
 
     <!-- leave reports -->
@@ -161,7 +161,7 @@
         <field name="perm_unlink" eval="False" />
         <field
             name="domain_force"
-        >[("employee_id.parent_id.user_id", "=", user.id)]</field>
+        >[("employee_id", "child_of", user.employee_ids.id)]</field>
     </record>
 
     <!-- an hr officer should have read-only access to all leave reports -->

--- a/provelo_custom/tests/__init__.py
+++ b/provelo_custom/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hr_data_access

--- a/provelo_custom/tests/test_hr_data_access.py
+++ b/provelo_custom/tests/test_hr_data_access.py
@@ -1,0 +1,131 @@
+import odoo.tests.common as common
+from odoo.exceptions import AccessError
+
+
+class TestHRDataAcess(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self._create_users()
+        self._create_employees()
+        self._create_timesheets()
+        self._create_test_environement()
+
+    def _create_users(self):
+        # creating users with the same groups as Marc Demo
+        demo_groups = self.env.ref("base.user_demo").groups_id
+        self.bigboss_uid = self.env["res.users"].create(
+            {
+                "name": "Bigboss",
+                "login": "bigboss",
+                "email": "",
+                "groups_id": demo_groups,
+            }
+        )
+        self.boss_uid = self.env["res.users"].create(
+            {"name": "Boss", "login": "boss", "email": "", "groups_id": demo_groups}
+        )
+        self.employee_uid = self.env["res.users"].create(
+            {
+                "name": "Employee",
+                "login": "employee",
+                "email": "",
+                "groups_id": demo_groups,
+            }
+        )
+        self.external_uid = self.env["res.users"].create(
+            {
+                "name": "External",
+                "login": "external",
+                "email": "",
+                "groups_id": demo_groups,
+            }
+        )
+
+    def _create_employees(self):
+        self.bigboss_employee_id = self.env["hr.employee"].create(
+            {"name": "BigBoss", "user_id": self.bigboss_uid.id}
+        )
+        self.boss_employee_id = self.env["hr.employee"].create(
+            {
+                "name": "Boss",
+                "user_id": self.boss_uid.id,
+                "parent_id": self.bigboss_employee_id.id,
+            }
+        )
+        self.employee_employee_id = self.env["hr.employee"].create(
+            {
+                "name": "Employee",
+                "user_id": self.employee_uid.id,
+                "parent_id": self.boss_employee_id.id,
+            }
+        )
+        self.external_employee_id = self.env["hr.employee"].create(
+            {"name": "External", "user_id": self.external_uid.id}
+        )
+
+    def _create_timesheets(self):
+        self.bigboss_timesheet_id = self.env["hr_timesheet.sheet"].create(
+            {"employee_id": self.bigboss_employee_id.id}
+        )
+        self.boss_timesheet_id = self.env["hr_timesheet.sheet"].create(
+            {"employee_id": self.boss_employee_id.id}
+        )
+        self.employee_timesheet_id = self.env["hr_timesheet.sheet"].create(
+            {"employee_id": self.employee_employee_id.id}
+        )
+        self.external_timesheet_id = self.env["hr_timesheet.sheet"].create(
+            {"employee_id": self.external_employee_id.id}
+        )
+
+    def _create_test_environement(self):
+        self.bigboss_test_env = self.env["hr_timesheet.sheet"].sudo(self.bigboss_uid)
+        self.boss_test_env = self.env["hr_timesheet.sheet"].sudo(self.boss_uid)
+        self.employee_test_env = self.env["hr_timesheet.sheet"].sudo(self.employee_uid)
+        self.external_test_env = self.env["hr_timesheet.sheet"].sudo(self.external_uid)
+
+    def test_hr_access(self):
+        # External can access her own timesheet
+        self.assertEqual(
+            self.external_test_env.browse(self.external_timesheet_id.id).employee_id,
+            self.external_employee_id,
+        )
+
+        # Employee can access her own timesheet
+        self.assertEqual(
+            self.employee_test_env.browse(self.employee_timesheet_id.id).employee_id,
+            self.employee_employee_id,
+        )
+
+        # BigBoss can access Boss timesheet
+        self.assertEqual(
+            self.bigboss_test_env.browse(self.boss_timesheet_id.id).employee_id,
+            self.boss_employee_id,
+        )
+
+        # BigBoss can access Employee timesheet
+        self.assertEqual(
+            self.bigboss_test_env.browse(self.employee_timesheet_id.id).employee_id,
+            self.employee_employee_id,
+        )
+
+        # External cannot see any other timesheet
+        with self.assertRaises(AccessError):
+            self.external_test_env.browse(self.bigboss_timesheet_id.id).name
+        with self.assertRaises(AccessError):
+            self.external_test_env.browse(self.boss_timesheet_id.id).name
+        with self.assertRaises(AccessError):
+            self.external_test_env.browse(self.employee_timesheet_id.id).name
+
+        # Employee cannot see her bosses timesheets
+        with self.assertRaises(AccessError):
+            self.employee_test_env.browse(self.bigboss_timesheet_id.id).name
+        with self.assertRaises(AccessError):
+            self.employee_test_env.browse(self.boss_timesheet_id.id).name
+
+        # Boss cannot see Bigboss timesheet
+        with self.assertRaises(AccessError):
+            self.boss_test_env.browse(self.bigboss_timesheet_id.id).name
+
+        # BigBoss cannot see External timesheet
+        with self.assertRaises(AccessError):
+            self.bigboss_test_env.browse(self.external_timesheet_id.id).name


### PR DESCRIPTION
Task : https://gestion.coopiteasy.be/web#id=7822&view_type=form&model=project.task&action=479

- Allow manager to access his/her employees data (not only n-1 but n-*)
- Allow for the special case where a user is linked to multiple employees using `.mapped("id")` instead of `.id` 