### PR TITLE
[FIX] rotordc_autofill_product_variant: missing return statement

### DIFF
--- a/rotordc_autofill_product_variant/models/product_product.py
+++ b/rotordc_autofill_product_variant/models/product_product.py
@@ -39,4 +39,4 @@ class ProductProduct(models.Model):
                     vals["product_height"] = product_tmpl_id.product_height
                 if "product_width" not in vals:
                     vals["product_width"] = product_tmpl_id.product_width
-        super().create(vals_list)
+        return super().create(vals_list)


### PR DESCRIPTION
This bit of code in models.py depends on the create function to return a RecordSet : 

```py
        # create records
        records = self._load_records_create([data['values'] for data in to_create])
        for data, record in pycompat.izip(to_create, records):
            data['record'] = record
```

Missing return in overriding create function breaks the return chain.