### PR TITLE
[FIX] provelo_resource_activity_reports: registration report

### DIFF
--- a/provelo_resource_activity_reports/readme/CREDITS.rst
+++ b/provelo_resource_activity_reports/readme/CREDITS.rst
@@ -1,0 +1,1 @@
+* `Pro Vélo <https://www.provelo.org>`_

--- a/provelo_resource_activity_reports/readme/newsfragments/74.bugfix.rst
+++ b/provelo_resource_activity_reports/readme/newsfragments/74.bugfix.rst
@@ -1,0 +1,1 @@
+Product template ids were assigned to product product field. Fixed.

--- a/provelo_resource_activity_reports/reports/resource_activity_registration_report.py
+++ b/provelo_resource_activity_reports/reports/resource_activity_registration_report.py
@@ -67,7 +67,7 @@ class ResourceActivityRegistrationReport(models.Model):
     need_delivery = fields.Boolean(string="Need Delivery?", readonly=True)
     need_guide = fields.Boolean(string="Need Guide?", readonly=True)
     product_id = fields.Many2one(
-        comodel_name="product.product", string="Product", readonly=True
+        comodel_name="product.template", string="Product", readonly=True
     )
     product_categ_id = fields.Many2one(
         comodel_name="product.category",


### PR DESCRIPTION
## Description

Dans le rapport des "Inscriptions", quand on divise par "Article" on a des articles chelous, qui ne correspondent pas aux activités.

=> product template ids were assigned to product product field

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=8872&action=475&active_id=198&model=project.task&view_type=form&menu_id=536

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
