### PR TITLE
[FIX] provelo_custom_timesheet_ui: Fix display of timesheet_overtime

### DIFF
--- a/provelo_custom_timesheet_ui/views/hr_timesheet_sheet_views.xml
+++ b/provelo_custom_timesheet_ui/views/hr_timesheet_sheet_views.xml
@@ -14,14 +14,15 @@
     <record id="hr_timesheet_sheet_tree" model="ir.ui.view">
         <field name="name">provelo_custom_timesheet_ui.timesheet.sheet.tree</field>
         <field name="model">hr_timesheet.sheet</field>
-        <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_tree" />
+        <!--
+            Inheriting from hr_timesheet_overtime because it introduces the
+            timesheet_overtime field.
+        -->
+        <field name="inherit_id" ref="hr_timesheet_overtime.hr_timesheet_sheet_tree" />
         <field name="arch" type="xml">
             <field name="reviewer_id" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <xpath expr="//tree" position="inside">
-                <field name="timesheet_overtime" invisible="1" />
-            </xpath>
             <xpath expr="//tree" position="attributes">
                 <attribute
                     name="decoration-warning"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,16 @@
 freezegun
 
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_base
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/member_card
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/eater
+git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/eater_member_card
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_product
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_account
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_product_info_screen
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_worker_status
 git+https://github.com/beescoop/obeesdoo@12.0#subdirectory=setup/beesdoo_shift
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/sale_order_volume
+git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/company_supplier_context
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/csv_export_base
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/sftp_backend
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/csv_export_invoice


### PR DESCRIPTION


Signed-off-by: Carmen Bianca Bakker <carmen@coopiteasy.be>

## Description

Previously, using this module, timesheet_overtime was shown as a decimal
in the UI. I suspect this is because this module re-defined the
timesheet_overtime field without specifying widget="float_time".

By inheriting directly from the hr_timesheet_overtime module, this
problem is circumvented.

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=4362&active_id=4362&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
