### PR TITLE
[ADD] provelo_timesheet_hide_to_review

### DIFF
--- a/provelo_timesheet_hide_to_review/__init__.py
+++ b/provelo_timesheet_hide_to_review/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/provelo_timesheet_hide_to_review/__manifest__.py
+++ b/provelo_timesheet_hide_to_review/__manifest__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "Pro Velo Timesheet Hide To Review",
+    "summary": """
+        Hide 'To Review' menu from the top bar.""",
+    "version": "12.0.1.0.0",
+    "category": "Human Resources",
+    "website": "https://coopiteasy.be",
+    "author": "Coop IT Easy SC",
+    "maintainers": ["carmenbianca"],
+    "license": "AGPL-3",
+    "application": False,
+    "depends": [
+        "hr_timesheet_sheet",
+    ],
+    "excludes": [],
+    "data": [
+        "views/hr_timesheet_sheet_views.xml",
+    ],
+    "demo": [],
+    "qweb": [],
+}

--- a/provelo_timesheet_hide_to_review/readme/CONTRIBUTORS.rst
+++ b/provelo_timesheet_hide_to_review/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SC <https://coopiteasy.be>`_:
+
+  * Carmen Bianca Bakker

--- a/provelo_timesheet_hide_to_review/readme/DESCRIPTION.rst
+++ b/provelo_timesheet_hide_to_review/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Hide 'To Review' menu from the top bar.

--- a/provelo_timesheet_hide_to_review/views/hr_timesheet_sheet_views.xml
+++ b/provelo_timesheet_hide_to_review/views/hr_timesheet_sheet_views.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<odoo>
+    <record id="hr_timesheet_sheet.menu_hr_to_review" model="ir.ui.menu">
+        <field name="active">False</field>
+    </record>
+</odoo>

--- a/setup/provelo_timesheet_hide_to_review/odoo/addons/provelo_timesheet_hide_to_review
+++ b/setup/provelo_timesheet_hide_to_review/odoo/addons/provelo_timesheet_hide_to_review
@@ -1,0 +1,1 @@
+../../../../provelo_timesheet_hide_to_review

--- a/setup/provelo_timesheet_hide_to_review/setup.py
+++ b/setup/provelo_timesheet_hide_to_review/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Signed-off-by: Carmen Bianca Bakker <carmen@coopiteasy.be>

## Description

Not sure if this is the best solution, but there's no 'invisible' field
on ir.ui.menu objects. Alternatively, we could set `groups_id` (M2M) to
some new empty group, effectively making the menu only visible to people
in the empty group.

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=8738&active_id=8738&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
