### PR TITLE
[12.0] hide the timesheet "to review" menu item

### DIFF
--- a/provelo_custom/security/security.xml
+++ b/provelo_custom/security/security.xml
@@ -263,6 +263,9 @@
         <field name="model_id" ref="model_hr_timesheet_overtime" />
         <field name="groups" eval="[(4, ref('base.group_user'))]" />
         <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_unlink" eval="False" />
         <field name="domain_force">[("employee_id.user_id", "=", user.id)]</field>
     </record>
 
@@ -275,6 +278,9 @@
         <field name="model_id" ref="model_hr_timesheet_overtime" />
         <field name="groups" eval="[(4, ref('base.group_user'))]" />
         <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_unlink" eval="False" />
         <field
             name="domain_force"
         >[("employee_id", "child_of", user.employee_ids.mapped("id"))]</field>
@@ -286,7 +292,9 @@
         <field name="model_id" ref="model_hr_timesheet_overtime" />
         <field name="groups" eval="[(4, ref('hr.group_hr_user'))]" />
         <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_unlink" eval="False" />
         <field name="domain_force" eval="False" />
     </record>
-
 </odoo>

--- a/provelo_custom/views/hr_timesheet_sheet_view.xml
+++ b/provelo_custom/views/hr_timesheet_sheet_view.xml
@@ -74,4 +74,9 @@
             eval="[(4, ref('hr_auto_manager_group_membership.group_employee_manager'))]"
         />
     </record>
+
+    <!-- make this menuitem visible to administrators only. -->
+    <record model="ir.ui.menu" id="hr_timesheet_sheet.menu_hr_to_review">
+        <field name="groups_id" eval="[(4, ref('base.group_system'))]" />
+    </record>
 </odoo>


### PR DESCRIPTION
## description

hide the timesheet "to review" menu item for all users except the admin. fix also some missing permissions in record rules.

## odoo task

[t8738](https://gestion.coopiteasy.be/web#id=8738&model=project.task&view_type=form)

should replace #80.