### PR TITLE
[ADD] rotordc_sale_related_so

### DIFF
--- a/rotordc_report_picking_huge_sale_order/report/report_stockpicking_operations.xml
+++ b/rotordc_report_picking_huge_sale_order/report/report_stockpicking_operations.xml
@@ -2,7 +2,11 @@
 <odoo>
     <template id="report_picking" inherit_id="stock.report_picking">
         <xpath expr="//div[hasclass('page')]" position="inside">
-            <p t-field="o.origin" style="text-align: center; font-size: 10rem;" />
+            <p
+                name="huge_origin_so"
+                t-field="o.origin"
+                style="text-align: center; font-size: 10rem;"
+            />
         </xpath>
     </template>
 </odoo>

--- a/rotordc_sale_related_so/__init__.py
+++ b/rotordc_sale_related_so/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import models

--- a/rotordc_sale_related_so/__manifest__.py
+++ b/rotordc_sale_related_so/__manifest__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+{
+    "name": "RotorDC Sale Linked SO",
+    "summary": """
+        Adds M2M links between SOs.""",
+    "version": "12.0.1.0.0",
+    "category": "Warehouse",
+    "website": "https://coopiteasy.be",
+    "author": "Coop IT Easy SC",
+    "maintainers": ["robinkeunen"],
+    "license": "AGPL-3",
+    "application": False,
+    "depends": [
+        "sale_stock",
+    ],
+    "excludes": [],
+    "data": [
+        "views/sale_order_views.xml",
+        "views/stock_picking_views.xml",
+        "security/ir.model.access.csv",
+    ],
+    "demo": [],
+    "qweb": [],
+}

--- a/rotordc_sale_related_so/__manifest__.py
+++ b/rotordc_sale_related_so/__manifest__.py
@@ -15,11 +15,13 @@
     "application": False,
     "depends": [
         "sale_stock",
+        "rotordc_report_picking_huge_sale_order",
     ],
     "excludes": [],
     "data": [
         "views/sale_order_views.xml",
         "views/stock_picking_views.xml",
+        "report/report_stockpicking_operations.xml",
         "security/ir.model.access.csv",
     ],
     "demo": [],

--- a/rotordc_sale_related_so/models/__init__.py
+++ b/rotordc_sale_related_so/models/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from . import sale_order
+from . import stock_picking

--- a/rotordc_sale_related_so/models/sale_order.py
+++ b/rotordc_sale_related_so/models/sale_order.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import api, fields, models
+
+
+class SaleOrderGroup(models.Model):
+    _name = "sale.order.group"
+    _description = "A group of related sale orders"
+
+    sale_order_ids = fields.One2many(
+        comodel_name="sale.order",
+        inverse_name="sale_order_group_id",
+    )
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    sale_order_group_id = fields.Many2one(
+        comodel_name="sale.order.group",
+    )
+    related_so_ids = fields.Many2many(
+        string="Linked Sale Orders",
+        comodel_name="sale.order",
+        compute="_compute_related_sale_orders",
+    )
+
+    @api.multi
+    def create_related_sale_order(self):
+        self.ensure_one()
+        if not self.sale_order_group_id:
+            self.sale_order_group_id = self.env["sale.order.group"].create({})
+
+        ctx = {
+            "default_partner_id": self.partner_id.id,
+            "default_origin": self.name,
+            "default_sale_order_group_id": self.sale_order_group_id.id,
+        }
+        return {
+            "type": "ir.actions.act_window",
+            "view_type": "form",
+            "view_mode": "form",
+            "res_model": "sale.order",
+            "target": "current",
+            "context": ctx,
+        }
+
+    @api.multi
+    @api.depends("sale_order_group_id.sale_order_ids")
+    def _compute_related_sale_orders(self):
+        for so in self:
+            if so.sale_order_group_id:
+                so.related_so_ids = so.sale_order_group_id.sale_order_ids.filtered(
+                    lambda related_so: related_so != so
+                )

--- a/rotordc_sale_related_so/models/stock_picking.py
+++ b/rotordc_sale_related_so/models/stock_picking.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    related_so_ids = fields.Many2many(
+        string="Linked Sale Orders",
+        related="sale_id.related_so_ids",
+    )

--- a/rotordc_sale_related_so/readme/CONTRIBUTORS.rst
+++ b/rotordc_sale_related_so/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Coop IT Easy SC <https://coopiteasy.be>`_:
+
+  * Robin Keunen

--- a/rotordc_sale_related_so/readme/CREDITS.rst
+++ b/rotordc_sale_related_so/readme/CREDITS.rst
@@ -1,0 +1,2 @@
+The development of this module has been paid for by
+`Rotor Deconstruction <https://rotordc.com/>`_.

--- a/rotordc_sale_related_so/readme/DESCRIPTION.rst
+++ b/rotordc_sale_related_so/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+Add links between related sale orders
+
+- a button creates a new SO from a SO
+- m2m field `related_so_ids` tracks the links between so
+- the linked SOs are displayed on the picking form and report

--- a/rotordc_sale_related_so/report/report_stockpicking_operations.xml
+++ b/rotordc_sale_related_so/report/report_stockpicking_operations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="report_picking"
+        inherit_id="rotordc_report_picking_huge_sale_order.report_picking"
+    >
+        <xpath expr="//p[@name='huge_origin_so']" position="after">
+            <t t-if="o.related_so_ids">
+                <p style="text-align: center; font-size: 3rem;">
+                    <t t-foreach="o.related_so_ids" t-as="so">
+                        <span t-field="so.name" />
+                    </t>
+                </p>
+            </t>
+        </xpath>
+    </template>
+</odoo>

--- a/rotordc_sale_related_so/security/ir.model.access.csv
+++ b/rotordc_sale_related_so/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_group,access_sale_order_group,model_sale_order_group,base.group_user,1,1,1,1

--- a/rotordc_sale_related_so/tests/__init__.py
+++ b/rotordc_sale_related_so/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_related_sale_orders

--- a/rotordc_sale_related_so/tests/test_related_sale_orders.py
+++ b/rotordc_sale_related_so/tests/test_related_sale_orders.py
@@ -1,0 +1,48 @@
+# Copyright 2023 Coop IT Easy SC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import SavepointCase
+
+
+class TestRelatedSaleOrders(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestRelatedSaleOrders, cls).setUpClass()
+        cls.sale_order_obj = cls.env["sale.order"]
+        cls.customer = cls.env.ref("base.res_partner_1")
+        cls.other_customer = cls.env.ref("base.res_partner_2")
+
+    def _create_so(self, name, parent_so=None):
+        vals = {
+            "partner_id": self.customer.id,
+            "name": name,
+        }
+        if parent_so:
+            if not parent_so.sale_order_group_id:
+                parent_so.sale_order_group_id = self.env["sale.order.group"].create({})
+            vals["sale_order_group_id"] = parent_so.sale_order_group_id.id
+
+        return self.sale_order_obj.create(vals)
+
+    def test_discover_single_so(self):
+        so = self._create_so("X")
+        self.assertFalse(so.sale_order_group_id)
+        self.assertFalse(so.related_so_ids)
+
+    def test_discover_related_tree_for_sale_order_tree(self):
+        """
+        A ──► B ──► C
+              │
+              └───► D ──► E
+        """
+        A = self._create_so(name="A")
+        B = self._create_so(name="B", parent_so=A)
+        C = self._create_so(name="C", parent_so=B)
+        D = self._create_so(name="D", parent_so=B)
+        E = self._create_so(name="E", parent_so=D)
+
+        self.assertEqual(sorted(A.related_so_ids.mapped("name")), list("BCDE"))
+        self.assertEqual(sorted(B.related_so_ids.mapped("name")), list("ACDE"))
+        self.assertEqual(sorted(C.related_so_ids.mapped("name")), list("ABDE"))
+        self.assertEqual(sorted(D.related_so_ids.mapped("name")), list("ABCE"))
+        self.assertEqual(sorted(E.related_so_ids.mapped("name")), list("ABCD"))

--- a/rotordc_sale_related_so/views/sale_order_views.xml
+++ b/rotordc_sale_related_so/views/sale_order_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_order_view_form" model="ir.ui.view">
+        <field name="name">sale.order.form.rotordc.sale.related.so</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="payment_term_id" position="after">
+                <field name="origin" readonly="1" />
+            </field>
+            <page name="other_information" position="before">
+                <page string="Related Sale Orders" name="linked_sale_orders">
+                    <button
+                        name="create_related_sale_order"
+                        type="object"
+                        string="Create Related Sale Order"
+                        class="oe_link"
+                    />
+                    <group>
+                        <field name="related_so_ids" nolabel="1">
+                            <tree>
+                                <control>
+                                    <create
+                                        string="Create SO"
+                                        context="{'default_origin': name}"
+                                    />
+                                </control>
+                                <field name="name" />
+                                <field name="confirmation_date" />
+                                <field name="partner_id" />
+                                <field name="user_id" />
+                                <field name="amount_total" />
+                                <field name="state" />
+                                <field name="invoice_status" />
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </page>
+        </field>
+    </record>
+
+    <record id="sale_order_view_quotation_tree" model="ir.ui.view">
+        <field name="name">sale.order.tree.rotordc.sale.related.so</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_quotation_tree" />
+        <field name="arch" type="xml">
+            <field name="state" position="before">
+                <field name="related_so_ids" widget="many2many_tags" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/rotordc_sale_related_so/views/stock_picking_views.xml
+++ b/rotordc_sale_related_so/views/stock_picking_views.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_form" model="ir.ui.view">
+        <field name="name">stock.picking.form.related.so</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="arch" type="xml">
+            <field name="origin" position="attributes">
+                <attribute
+                    name="attrs"
+                >{"invisible": [("sale_id", "!=", False)]}</attribute>
+            </field>
+            <field name="origin" position="after">
+                <field
+                    name="sale_id"
+                    attrs='{"invisible": [("sale_id", "=", False)]}'
+                />
+            </field>
+            <page name="extra" position="before">
+                <page string="Related Sale Orders" name="related_sale_orders">
+                    <group>
+                        <field name="related_so_ids" nolabel="1">
+                            <tree>
+                                <control>
+                                    <create
+                                        string="Create SO"
+                                        context="{'default_origin': name}"
+                                    />
+                                </control>
+                                <field name="name" />
+                                <field name="confirmation_date" />
+                                <field name="partner_id" />
+                                <field name="user_id" />
+                                <field name="amount_total" />
+                                <field name="state" />
+                                <field name="invoice_status" />
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </page>
+        </field>
+    </record>
+</odoo>

--- a/setup/rotordc_sale_related_so/odoo/addons/rotordc_sale_related_so
+++ b/setup/rotordc_sale_related_so/odoo/addons/rotordc_sale_related_so
@@ -1,0 +1,1 @@
+../../../../rotordc_sale_related_so

--- a/setup/rotordc_sale_related_so/setup.py
+++ b/setup/rotordc_sale_related_so/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Description

Add links between related sale orders

- a button creates a new SO from a SO
- m2m field `related_so_ids` tracks the links between so
- the linked SOs are displayed on the picking form and report


## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=10397&model=project.task&view_type=form&menu_id=

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
  - feels like an necessary development : the use case could be handled by modifying the original SO.
