### PR TITLE
[12.0][IMP] search through all tasks in timesheet lines

### DIFF
--- a/coopiteasy_custom/__manifest__.py
+++ b/coopiteasy_custom/__manifest__.py
@@ -14,6 +14,7 @@
         Specific customizations for Coop IT Easy
     """,
     "depends": [
+        "hr_timesheet_search_all_tasks",
         "hr_timesheet_sheet",
         "hr_timesheet_task_change_project",
         "project_status",

--- a/coopiteasy_custom/models/__init__.py
+++ b/coopiteasy_custom/models/__init__.py
@@ -1,2 +1,3 @@
+from . import account_analytic_line
 from . import project_task
 from . import project_project

--- a/coopiteasy_custom/models/account_analytic_line.py
+++ b/coopiteasy_custom/models/account_analytic_line.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo import api, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    @api.onchange("project_id")
+    def _set_task_domain_on_project_change(self):
+        result = super()._set_task_domain_on_project_change()
+        if not result["domain"]["task_id"]:
+            result["domain"]["task_id"] = [
+                ("project_id.project_status.is_closed", "=", False)
+            ]
+        return result

--- a/coopiteasy_custom/readme/DESCRIPTION.rst
+++ b/coopiteasy_custom/readme/DESCRIPTION.rst
@@ -2,5 +2,7 @@ This module:
 
 * adds reset_so_line on account.analytic.line
 * adds fields on project.task
-* only display active accounts on activity view
-* sorts accounts by line count
+* only allows to select open projects in timesheet line views
+* only allows to select tasks of open projects in timesheet line views (when
+  directly selecting a task without selecting a project first)
+* sorts projects by timesheet line count

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -31,7 +31,7 @@ git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/sale_order_volu
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/company_supplier_context
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/account_customer_wallet
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/pos_customer_wallet
-git+https://github.com/coopiteasy/addons@12.0-split-spp_portal_customer_wallet#subdirectory=setup/portal_customer_wallet
+git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/portal_customer_wallet
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/csv_export_base
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/sftp_backend
 # git+https://github.com/coopiteasy/csv-connector@12.0#subdirectory=setup/csv_export_invoice
@@ -46,6 +46,7 @@ git+https://github.com/coopiteasy/account-invoicing@12.0-account_invoice_date_re
 git+https://github.com/coopiteasy/account-invoicing@12.0-account_invoice_negative_total#subdirectory=setup/account_invoice_negative_total
 git+https://github.com/coopiteasy/cie-timesheet@12.0#subdirectory=setup/hr_timesheet_task_change_project
 git+https://github.com/coopiteasy/cie-timesheet@12.0#subdirectory=setup/hr_timesheet_overtime
+git+https://github.com/coopiteasy/cie-timesheet@12.0#subdirectory=setup/hr_timesheet_search_all_tasks
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/resource_work_time_from_contracts
 git+https://github.com/coopiteasy/addons@12.0#subdirectory=setup/company_today
 git+https://github.com/fcayre/odoo-usability@12.0-fix-account_usability-and-make-pip-installable#subdirectory=setup/sale_down_payment


### PR DESCRIPTION
allow to directly select a task (from open projects only) in a timesheet line without selecting a project first.

this is mainly handled by `hr_timesheet_search_all_tasks` (coopiteasy/cie-timesheet#26), which is added as a dependency. this module changes the behavior to limit the available tasks to those of open projects only.