### PR TITLE
Update location_filters.xml to match our new location's name

### DIFF
--- a/provelo_custom/views/location_filters.xml
+++ b/provelo_custom/views/location_filters.xml
@@ -16,8 +16,8 @@
                 <filter name="Liège" domain="[('location_id','ilike','Liège')]" />
                 <filter name="Mons" domain="[('location_id','ilike','Mons')]" />
                 <filter
-                    name="Ottignies"
-                    domain="[('location_id','ilike','Ottignies')]"
+                    name="LLN"
+                    domain="[('location_id','ilike','Louvain-la-Neuve')]"
                 />
                 <filter name="Namur" domain="[('location_id','ilike','Namur')]" />
                 <filter name="Gembloux" domain="[('location_id','ilike','Gembloux')]" />


### PR DESCRIPTION
Hello Coop IT Easy,

We moved from Ottignies to Louvain-la-Neuve, hence we needed to adapt this filter.

Could you please have it installed next time you push code into production?
In the meantime, we'll manually update the filter on our instance.

Thanks in advance,

Jérémie